### PR TITLE
Fix crash when using module with Appium

### DIFF
--- a/src/EyesWDIO.js
+++ b/src/EyesWDIO.js
@@ -1257,7 +1257,13 @@ class EyesWDIO extends EyesBase {
 
           if (platformName) {
             let os = platformName;
-            const platformVersion = that.getDriver().remoteWebDriver.desiredCapabilities.platformVersion;
+            let platformVersion = '';
+            if (that.getDriver().remoteWebDriver.desiredCapabilities) {
+              platformVersion = that.getDriver().remoteWebDriver.desiredCapabilities.platformVersion;
+            } else if (that.getDriver().remoteWebDriver.capabilities) {
+              platformVersion = that.getDriver().remoteWebDriver.capabilities.platformVersion;
+            }
+
             if (platformVersion) {
               os += ` ${platformVersion}`;
             }


### PR DESCRIPTION
I was having crash using this module with Appium. The support ticket inside Applitools' system was #28510.

This pull-requests fixes the problem by checking when `desiredCapabilities` are not available and using `capabilities` instead.